### PR TITLE
add program counter

### DIFF
--- a/modules/program-counter.v
+++ b/modules/program-counter.v
@@ -1,0 +1,11 @@
+module program_counter (
+    input wire clk,
+    input wire [31:0] pc_in,
+    output wire [31:0] pc_out
+);
+    reg [31:0] data; // reg = register, a datatype that is usually implemented in hardware as a flipflop 
+    always @(posedge clk) //everytime the clock changes its value from 0 to 1 
+        data <= pc_in;    //update the value in data to the value in pc_in  
+    
+    assign pc_out = data; //conects a wire to the output of the data register 
+endmodule


### PR DESCRIPTION
Tested with:
```
module pc_tb();
  reg [31:0] in;
  reg clk;
  wire [31:0] out;
  
  program_counter pc(
    .clk(clk),
    .pc_in(in),
    .pc_out(out)
  );
  
  initial begin
    $dumpfile("pc_tb.vcd");
    $dumpvars(0, pc_tb);
    
    in = 0;
    clk = 0;
    
    #10;
    	in = 'h80000000;
    #10;
    	clk = 1;
    #10;
    	in = 'h00000000;
    #10;
    	clk = 0;
    #10;
    
  end
  
endmodule
```

<img width="1421" alt="Captura de Tela 2024-07-17 às 01 00 45" src="https://github.com/user-attachments/assets/1859ca95-366a-4fe3-9bf1-b59c9b68d373">

Didn't know how to make the initial value for the register 0. 